### PR TITLE
Fix PHP syntax error

### DIFF
--- a/classes/incident.php
+++ b/classes/incident.php
@@ -84,7 +84,7 @@ class Incident implements JsonSerializable
     $user_id = $_SESSION['user'];
     $type = $_POST['type'];
     $title = strip_tags($_POST['title']);
-    $text = strip_tags($_POST['text'], '<br>')
+    $text = strip_tags($_POST['text'], '<br>');
 
     if (strlen($title)==0)
     {


### PR DESCRIPTION
Added a semicolon that allows fresh installations on *NIX to work properly with PHP 7.2+