### PR TITLE
Updated sorting, version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It means the beta that is heavily unstable that is meant for contributors to mak
 #### Public Beta
 ##### This beta has some bugs that are not really noticeable and mostly exist as bugs. Best for trying the new features before updating!
 -->
-Very simple server status page written in PHP that can run on **PHP 5.4+** - even on **shared webhosting** even without shell access. Because why waste your money on another server (or host on a server that you might want to do maintenance on), when you can use cheap webhosting? And as a cherry on top - it works even without javascript!
+Very simple server status page written in PHP that can run on **PHP 5.5+** - even on **shared webhosting** even without shell access. Because why waste your money on another server (or host on a server that you might want to do maintenance on), when you can use cheap webhosting? And as a cherry on top - it works even without javascript!
 
 ## How do I install this thing?
 Simply put the files on your server and access it from your browser. There will be a simple install dialog waiting for you.

--- a/classes/constellation.php
+++ b/classes/constellation.php
@@ -73,7 +73,7 @@ class Constellation
     global $mysqli;
 
     //$query = $mysqli->query("SELECT id, name, description FROM services");
-    $query = $mysqli->query("SELECT services.id, services.name, services.description, services_groups.name as group_name FROM services LEFT JOIN services_groups ON services.group_id=services_groups.id ORDER BY services_groups.name ");
+    $query = $mysqli->query("SELECT services.id, services.name, services.description, services_groups.name as group_name FROM services LEFT JOIN services_groups ON services.group_id=services_groups.id ORDER BY services_groups.name ASC, services.name;");
     $array = array();
     if ($query->num_rows){
       $timestamp = time();


### PR DESCRIPTION
Updated sorting of services to service group, then service name, ascending. Previous behavior would sort by service group, then defaulted to ID, so services were in an arbitrary order when rendered using Constellation.

Updated minimum version in README from PHP 5.4 to PHP 5.5. See issue #168 on handling of constants with methods in PHP.